### PR TITLE
add "develop" item to the drop-down menu "Document"

### DIFF
--- a/index.cn.html
+++ b/index.cn.html
@@ -43,10 +43,10 @@
             <ul class="site-links">
                 <li><a class="active">主页</a></li>
                 <li><a href="http://book.paddlepaddle.org/index.cn.html" target="_blank">快速开始</a></li>
-                <li><a href="http://doc.paddlepaddle.org/doc_cn/howto/index_cn.html" target="_blank">文档中心</a></li>
                 <li class="version-switcher">
-                    <a>版本<i class="fa" aria-hidden="true"></i>&nbsp;&nbsp;&nbsp;&nbsp;</a>
+                    <a>文档中心<i class="fa" aria-hidden="true"></i>&nbsp;&nbsp;&nbsp;&nbsp;</a>
                     <ul>
+                        <li><a href="http://doc.paddlepaddle.org/develop/doc_cn/" target="_blank">develop</a></li>
                         <li><a href="http://doc.paddlepaddle.org/release/0.10.0/doc_cn/" target="_blank">0.10.0</a></li>
                         <li><a href="http://doc.paddlepaddle.org/release_doc/0.9.0/doc_cn/" target="_blank">0.9.0</a></li>
                     </ul>

--- a/index.html
+++ b/index.html
@@ -43,10 +43,10 @@
             <ul class="site-links">
                 <li><a class="active">Home</a></li>
                 <li><a href="http://book.paddlepaddle.org/index.html" target="_blank">Quick Start</a></li>
-                <li><a href="http://doc.paddlepaddle.org/doc/howto/index_en.html" target="_blank">Documentation</a></li>
                 <li class="version-switcher">
-                    <a>Version<i class="fa" aria-hidden="true"></i></a>
+                    <a>Documentation<i class="fa" aria-hidden="true"></i></a>
                     <ul>
+                        <li><a href="http://doc.paddlepaddle.org/develop/doc/" target="_blank">develop</a></li>
                         <li><a href="http://doc.paddlepaddle.org/release/0.10.0/doc/" target="_blank">0.10.0</a></li>
                         <li><a href="http://doc.paddlepaddle.org/release_doc/0.9.0/doc/" target="_blank">0.9.0</a></li>
                     </ul>


### PR DESCRIPTION
fix https://github.com/PaddlePaddle/Paddle/issues/3686
- 英文：去掉Document栏，将Version栏改名为Document，下面多设了一个develop的菜单。
- 中文：去掉“文档中心”栏，将“版本”栏改名为“文档中心”，下面多设了一个develop的菜单。